### PR TITLE
Ajout d'un loading quand on accède aux podcast

### DIFF
--- a/src/App/Modules/RSSFeed/List.js
+++ b/src/App/Modules/RSSFeed/List.js
@@ -59,7 +59,8 @@ function RSSFeedList() {
 
   return <Table titleLeft={getLocale('discover-rss-feed')}
                 data={rssFeedTableData}
-                onSelect={onSelect}/>
+                onSelect={onSelect}
+                isLoading={!rssFeedTableData.length}/>
 }
 
 export default RSSFeedList


### PR DESCRIPTION
Lorsqu'on arrive sur la tab, le temps de charger toute la liste de podcast peut prendre un peu de temps.
En ce moment, j'ai des soucis de connexion, du coup, ça prend 3-4 secondes
Un petit loading peut être sympa du coup