### PR TITLE
Fix UI crash with "banner" missing from store json

### DIFF
--- a/src/App/Modules/Stores/Store/AudioList/StoreAudioListContent.js
+++ b/src/App/Modules/Stores/Store/AudioList/StoreAudioListContent.js
@@ -73,7 +73,7 @@ function StoreAudioListContent({store, storeData}) {
       additionalHeaderButtons={additionalHeaderButtons}
       isLoading={!stories.length}/>
     {
-      storeData !== null &&
+      storeData !== null && storeData.banner &&
       <div className={styles.audioListContainer}>
         <div className={styles.audioListContainerAbsolute}>
           <ButtonExternalLink href={storeData.banner.link}>

--- a/src/App/Modules/Stores/Store/PacksList/StorePacksListContent.js
+++ b/src/App/Modules/Stores/Store/PacksList/StorePacksListContent.js
@@ -64,7 +64,7 @@ function StorePacksListContent({store, storeData}) {
       additionalHeaderButtons={additionalHeaderButtons}
       isLoading={!stories.length}/>
     {
-      storeData !== null &&
+      storeData !== null && storeData.banner &&
       <ButtonExternalLink href={storeData.banner.link}>
         <div className={styles.bannerContainer} style={{background: storeData.banner.background}}>
           <div className={styles.bannerInnerContainer}>


### PR DESCRIPTION
As I've been playing around with stores, I realized UI was crashing when loading a store json without "banner" element...