### PR TITLE
Parallélise les phases d'encodage audio/image (pool de N workers)

### DIFF
--- a/public/MainEvents/Helpers/ConcurrencyPool.js
+++ b/public/MainEvents/Helpers/ConcurrencyPool.js
@@ -1,0 +1,51 @@
+import * as os from 'os'
+
+const
+  getWorkerCount = () => {
+    const n = os.cpus().length
+    return n > 0 ? n : 1
+  },
+
+  // Runs `total` tasks (indexed 0..total-1) through `worker`, keeping up to
+  // getWorkerCount() of them in flight at once. A task's rejection is
+  // swallowed so the pool keeps going, mirroring the previous sequential
+  // recursion's error handling. `onItemSettled(settledCount)` fires each
+  // time a task finishes (success or failure), in completion order.
+  runConcurrentPool = (total, worker, onItemSettled) => {
+    return new Promise((resolve) => {
+      if (total <= 0) {
+        resolve()
+        return
+      }
+
+      const concurrency = Math.min(getWorkerCount(), total)
+      let nextIndex = 0
+      let settledCount = 0
+
+      const runNext = () => {
+        if (nextIndex >= total) {
+          return
+        }
+        const i = nextIndex++
+        worker(i)
+          .catch(() => {})
+          .then(() => {
+            settledCount++
+            if (typeof onItemSettled === 'function') {
+              onItemSettled(settledCount)
+            }
+            if (settledCount === total) {
+              resolve()
+            } else {
+              runNext()
+            }
+          })
+      }
+
+      for (let k = 0; k < concurrency; k++) {
+        runNext()
+      }
+    })
+  }
+
+export {getWorkerCount, runConcurrentPool}

--- a/public/MainEvents/Processes/Import/Helpers/AudioFile.js
+++ b/public/MainEvents/Processes/Import/Helpers/AudioFile.js
@@ -2,6 +2,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import {convertAudioToMp3} from '../../BinFiles/FFmpegCommand.js'
 import {findFile} from '../../../Helpers/Files.js'
+import {runConcurrentPool} from '../../../Helpers/ConcurrencyPool.js'
 
 const
   isAudioFile = (fileName) => {
@@ -15,20 +16,17 @@ const
   },
 
   convertAudios = (srcAudios, dstAudios, index, length, onEnd, forceConverting, forceVolume) => {
-    if (!srcAudios.length) {
+    const total = srcAudios.length
+    if (!total) {
       onEnd(index)
       return
     }
 
-    const
-      srcAudio = srcAudios.shift(),
-      dstAudio = dstAudios.shift()
-
-    process.stdout.write('*converting-audio*' + index + '*' + length + '*')
-
-    convertAudio(srcAudio, dstAudio, forceConverting, forceVolume)
-      .then(() => convertAudios(srcAudios, dstAudios, index + 1, length, onEnd, forceConverting, forceVolume))
-      .catch(() => convertAudios(srcAudios, dstAudios, index + 1, length, onEnd, forceConverting, forceVolume))
+    runConcurrentPool(
+      total,
+      (i) => convertAudio(srcAudios[i], dstAudios[i], forceConverting, forceVolume),
+      (settledCount) => process.stdout.write('*converting-audio*' + (index + settledCount) + '*' + length + '*')
+    ).then(() => onEnd(index + total))
   },
 
   checkCoverExists = (artist, album, coverPath) => {

--- a/public/MainEvents/Processes/Import/Helpers/ImageFile.js
+++ b/public/MainEvents/Processes/Import/Helpers/ImageFile.js
@@ -1,6 +1,7 @@
 import * as path from 'path'
 import {convertImageToPng} from '../../BinFiles/FFmpegCommand.js'
 import {findFile} from '../../../Helpers/Files.js'
+import {runConcurrentPool} from '../../../Helpers/ConcurrencyPool.js'
 
 const
   isImageFile = (fileName) => {
@@ -21,38 +22,35 @@ const
     await convertImageToPng(fromPath, toPath, 128, 128, textToWrite, pageNumber)
   },
   convertStoryImages = (srcImages, dstImages, textsToWrite, pagesNumbering, index, length, onEnd) => {
-    if (!srcImages.length) {
+    const total = srcImages.length
+    if (!total) {
       onEnd(index)
       return
     }
 
-    const
-      srcImage = srcImages.shift(),
-      dstImage = dstImages.shift(),
-      textToWrite = Array.isArray(textsToWrite) ? textsToWrite.shift() : undefined,
-      pageNumber = Array.isArray(pagesNumbering) ? pagesNumbering.shift() : undefined
-
-    process.stdout.write('*converting-images*' + index + '*' + length + '*')
-
-    convertStoryImage(srcImage, dstImage, textToWrite, pageNumber)
-      .then(() => convertStoryImages(srcImages, dstImages, textsToWrite, pagesNumbering, index + 1, length, onEnd))
-      .catch(() => convertStoryImages(srcImages, dstImages, textsToWrite, pagesNumbering, index + 1, length, onEnd))
+    runConcurrentPool(
+      total,
+      (i) => convertStoryImage(
+        srcImages[i],
+        dstImages[i],
+        Array.isArray(textsToWrite) ? textsToWrite[i] : undefined,
+        Array.isArray(pagesNumbering) ? pagesNumbering[i] : undefined
+      ),
+      (settledCount) => process.stdout.write('*converting-images*' + (index + settledCount) + '*' + length + '*')
+    ).then(() => onEnd(index + total))
   },
   convertInventoryImages = (srcImages, dstImages, index, length, onEnd) => {
-    if (!srcImages.length) {
+    const total = srcImages.length
+    if (!total) {
       onEnd(index)
       return
     }
 
-    const
-      srcImage = srcImages.shift(),
-      dstImage = dstImages.shift()
-
-    process.stdout.write('*converting-images*' + index + '*' + length + '*')
-
-    convertInventoryImage(srcImage, dstImage)
-      .then(() => convertInventoryImages(srcImages, dstImages, index + 1, length, onEnd))
-      .catch(() => convertInventoryImages(srcImages, dstImages, index + 1, length, onEnd))
+    runConcurrentPool(
+      total,
+      (i) => convertInventoryImage(srcImages[i], dstImages[i]),
+      (settledCount) => process.stdout.write('*converting-images*' + (index + settledCount) + '*' + length + '*')
+    ).then(() => onEnd(index + total))
   }
 
 export {


### PR DESCRIPTION
Les fonctions convertAudios et convertStoryImages/convertInventoryImages traitaient les fichiers un par un via une récursion séquentielle, donc un seul process ffmpeg tournait à la fois quel que soit le nombre de cœurs disponibles. Cette PR ajoute un pool de concurrence simple (ConcurrencyPool.js, N = os.cpus().length) pour lancer plusieurs conversions ffmpeg en parallèle, sans changer la signature ni le comportement externe de ces fonctions.