### PR TITLE
Correction des vignettes de couverture en dev

### DIFF
--- a/src/App/Components/Form/Input/InputImage.js
+++ b/src/App/Components/Form/Input/InputImage.js
@@ -3,6 +3,7 @@ import {useLocale} from '../../Locale/LocaleHooks.js'
 import InputLayout from './InputLayout.js'
 import ButtonIconXMark from '../../Buttons/Icons/ButtonIconXMark.js'
 import InputDropFile from './InputDropFile.js'
+import { imagePathToSrc } from '../../../Helpers/File.js'
 
 import styles from './Input.module.scss'
 
@@ -80,7 +81,7 @@ function InputImage(
                        id={id}
                        ref={refCallback}/>
         {imagePath &&
-          <img src={encodeURI(imagePath.replaceAll('\\', '/')) + '?time=' + Date.now()}
+          <img src={imagePathToSrc(imagePath) + '?time=' + Date.now()}
                className={styles.inputImageImg}
                alt=""/>}
       </div>

--- a/src/App/Components/Table/TableCell.js
+++ b/src/App/Components/Table/TableCell.js
@@ -8,6 +8,7 @@ import ButtonIconDownload from '../Buttons/Icons/ButtonIconDownload.js'
 import ButtonIconInfo from '../Buttons/Icons/ButtonIconInfo.js'
 import ButtonIconPlay from '../Buttons/Icons/ButtonIconPlay.js'
 import ButtonIconMicrophone from '../Buttons/Icons/ButtonIconMicrophone.js'
+import { imagePathToSrc } from '../../Helpers/File.js'
 
 import styles from './Table.module.scss'
 
@@ -79,7 +80,7 @@ function TableCell ({data, selected, onSelect, onPlay, onStudio, onInfo, onOptim
     <h5 className={styles.cellTitle} title={data.cellTitle}><span className={styles.cellEllipsis}>{data.cellTitle}</span></h5>
     {data.cellSubtitle && <p className={styles.cellSubtitle} title={data.cellSubtitle}><span className={styles.cellEllipsis}>{data.cellSubtitle}</span></p>}
     <div className={styles.imageContainer}>
-      <img src={data.image} className={styles.cellImage} alt="" loading="lazy"/>
+      <img src={imagePathToSrc(data.image)} className={styles.cellImage} alt="" loading="lazy"/>
       {data.cellLabelIcon && <p className={styles.cellImageLabel} title={data.cellLabelIconText}>{data.cellLabelIcon}</p>}
     </div>
     {

--- a/src/App/Components/Table/TableGroup.js
+++ b/src/App/Components/Table/TableGroup.js
@@ -8,6 +8,7 @@ import ButtonIconChevronUp from '../Buttons/Icons/ButtonIconChevronUp.js'
 import ButtonIconChevronDown from '../Buttons/Icons/ButtonIconChevronDown.js'
 import TableCell from './TableCell.js'
 import TableList from './TableList.js'
+import { imagePathToSrc } from '../../Helpers/File.js'
 
 import styles from './Table.module.scss'
 
@@ -116,7 +117,7 @@ function TableGroup({
             }
           </ul> :
           <div className={styles.groupList}>
-            <img className={styles.groupListImage} src={data.tableChildren[0].image} alt="" loading="lazy"/>
+            <img className={styles.groupListImage} src={imagePathToSrc(data.tableChildren[0].image)} alt="" loading="lazy"/>
             <ul className={styles.listContainer}>
               {
                 data.tableChildren.map(

--- a/src/App/Helpers/File.js
+++ b/src/App/Helpers/File.js
@@ -1,0 +1,19 @@
+const
+  {pathToFileURL} = window.require('url'),
+
+  // A scheme is two or more characters, so a Windows drive letter ("C:/...")
+  // is not mistaken for one.
+  hasScheme = (str) => /^[a-z][a-z0-9+.-]+:/i.test(str),
+
+  // Covers reach the renderer either as an absolute filesystem path (local
+  // stories and music) or as an http(s) URL (stores and RSS thumbnails). Only
+  // the former needs a scheme: a bare path in an <img src> is resolved against
+  // the page origin, which works in production, where the renderer is loaded
+  // from file://, but not in dev, where it is served from localhost:3000 and
+  // the dev server answers with index.html.
+  imagePathToSrc = (filePath) =>
+    typeof filePath !== 'string' || filePath === '' || hasScheme(filePath)
+      ? filePath
+      : pathToFileURL(filePath).href
+
+export {imagePathToSrc}


### PR DESCRIPTION
Les couvertures des histoires et des musiques arrivent au renderer sous forme de chemins de fichiers absolus bruts (`readStories` les construit avec `path.join(md.path, md.image)`). Dans un `<img src>`, un chemin sans schéma est résolu par rapport à l'origine de la page. Ça fonctionne en production, où le renderer est chargé avec `loadFile` et où l'origine est `file://` — mais pas en dev, où il est servi depuis `localhost:3000` : le chemin est résolu en `http://localhost:3000/Users/...`, le fallback SPA du serveur de dev répond `index.html`, et toutes les vignettes s'affichent cassées.

Un nouveau helper `src/App/Helpers/File.js` expose `imagePathToSrc`, qui convertit un chemin en URL `file://` et laisse intact tout ce qui porte déjà un schéma. Ce passthrough est nécessaire, pas défensif : `TableCell` affiche à la fois les couvertures locales et les vignettes des stores et des flux RSS, qui arrivent sous forme d'URLs `https`, parce que `StoriesTable` et `StoreHooks` étalent tous les deux leur objet source dans les données de la cellule.

Le helper utilise `url.pathToFileURL` plutôt qu'une concaténation de chaînes, pour que les lettres de lecteur Windows, les chemins UNC et les antislashs restent corrects, et pour que les caractères qui terminent une URL soient encodés. Ça corrige au passage `InputImage`, dont le `encodeURI` fait main laissait `#` et `?` bruts dans un nom de fichier et tronquait silencieusement l'URL à cet endroit. Le test de schéma exige deux caractères ou plus avant le deux-points, pour qu'un lecteur Windows (`C:/...`) ne soit pas pris pour un schéma.

Vérifié en dev sur une vraie bibliothèque : 6 couvertures locales se chargent en `file:///...` là où elles étaient cassées, 30 vignettes de store continuent de se charger en https sans changement, et le cache-buster `?time=` ajouté par `InputImage` fonctionne toujours sur une URL `file://`. La branche Windows de `pathToFileURL` n'a pas pu être exercée depuis macOS et n'est pas testée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)